### PR TITLE
website: move provisioner to aws_eip

### DIFF
--- a/website/intro/getting-started/provision.html.md
+++ b/website/intro/getting-started/provision.html.md
@@ -21,15 +21,15 @@ configuration management tools, etc.
 ## Defining a Provisioner
 
 To define a provisioner, modify the resource block defining the
-"example" EC2 instance to look like the following:
+"ip" AWS elastic IP to look like the following:
 
 ```hcl
-resource "aws_instance" "example" {
-  ami           = "ami-b374d5a5"
-  instance_type = "t2.micro"
+resource "aws_eip" "ip" {
+  instance = "${aws_instance.example.id}"
+  vpc      = true
 
   provisioner "local-exec" {
-    command = "echo ${aws_instance.example.public_ip} > ip_address.txt"
+    command = "echo ${aws_eip.ip.public_ip} > ip_address.txt"
   }
 }
 ```


### PR DESCRIPTION
# Reasoning for docs update
The output of ip_address.txt is blank. The local-exec provisioner, if run as part of aws_instance.example will use the public_ip of the instance, which is not the elastic IP's public IP.
The goal of this example is to show the learner that they can output the computed value of the public IP. Outputting the elastic IP more directly reflects that intent.

# Relevant Terraform version
Tested on v0.11.8
Should work on v0.6.9 or later